### PR TITLE
Add gov east1 ami to vpn meter

### DIFF
--- a/cloudformation-templates/avx-awsmp-5tunnel.template
+++ b/cloudformation-templates/avx-awsmp-5tunnel.template
@@ -129,14 +129,16 @@
             "eu-west-3":      { "Name": "ami-047ff80d631de8f0b", "Alias": "Paris" },
             "eu-north-1":     { "Name": "ami-4efd7630",          "Alias": "Stockholm" },
 
+            "ap-east-1":      { "Name": "ami-b94b30c8",          "Alias": "Hong Kong" },
             "ap-southeast-1": { "Name": "ami-0c017a6a429210e26", "Alias": "Singapore" },
             "ap-southeast-2": { "Name": "ami-0e2157909b24d0a37", "Alias": "Sydney" },
-            "ap-northeast-1": { "Name": "ami-0cc60ff3b54ae66a3", "Alias": "Tokyo" },
             "ap-northeast-2": { "Name": "ami-04ca2c656aecf8768", "Alias": "Seoul" },
-            "ap-east-1":      { "Name": "ami-b94b30c8",          "Alias": "Hong Kong" },
+            "ap-northeast-1": { "Name": "ami-0cc60ff3b54ae66a3", "Alias": "Tokyo" },
             "ap-south-1":     { "Name": "ami-08a22e1620c5ab3fa", "Alias": "Mumbai" },
 
             "sa-east-1":      { "Name": "ami-0ba041f9e2a611437", "Alias": "South America-Sao Paulo" },
+            "me-south-1":     { "Name": "ami-AWS_has_NOT_update_yet", "Alias": "Middle East Bahrain" },
+            "us-gov-east-1":  { "Name": "ami-AWS_has_NOT_update_yet", "Alias": "AWS Gov East 1" },
             "us-gov-west-1":  { "Name": "ami-48b7f029",          "Alias": "AWS Gov West 1" }
         }
     },
@@ -185,7 +187,9 @@
                                         "Fn::Join": [
                                             "",
                                             [
-                                                "arn:aws:iam::",
+                                                "arn:",
+                                                { "Ref" : "AWS::Partition" },
+                                                ":iam::",
                                                 {
                                                     "Ref": "AWS::AccountId"
                                                 },
@@ -221,7 +225,16 @@
                             "Action": [
                                 "sts:AssumeRole"
                             ],
-                            "Resource": "arn:aws:iam::*:role/aviatrix-*"
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "arn:",
+                                        { "Ref" : "AWS::Partition" },
+                                        ":iam::*:role/aviatrix-*"
+                                    ]
+                                ]
+                            }
                         },
                         {
                             "Effect": "Allow",

--- a/cloudformation-templates/avx-awsmp-BYOL.template
+++ b/cloudformation-templates/avx-awsmp-BYOL.template
@@ -130,14 +130,16 @@
             "eu-west-3":      { "Name": "ami-01838788ed74ad98d", "Alias": "Paris" },
             "eu-north-1":     { "Name": "ami-b2f378cc",          "Alias": "Stockholm" },
 
+            "ap-east-1":      { "Name": "ami-9a552eeb",          "Alias": "Hong Kong" },
             "ap-southeast-1": { "Name": "ami-0a9c6a012c943b907", "Alias": "Singapore" },
             "ap-southeast-2": { "Name": "ami-0e4d20f09c0318644", "Alias": "Sydney" },
-            "ap-northeast-1": { "Name": "ami-0d5e9b905bf30d2d3", "Alias": "Tokyo" },
             "ap-northeast-2": { "Name": "ami-0971c3882816c1bc4", "Alias": "Seoul" },
-            "ap-east-1":      { "Name": "ami-9a552eeb",          "Alias": "Hong Kong" },
+            "ap-northeast-1": { "Name": "ami-0d5e9b905bf30d2d3", "Alias": "Tokyo" },
             "ap-south-1":     { "Name": "ami-00c1c3e9df7b9ddd4", "Alias": "Mumbai" },
 
             "sa-east-1":      { "Name": "ami-0696240d0fc2ecc53", "Alias": "South America-Sao Paulo" },
+            "me-south-1":     { "Name": "ami-AWS_has_NOT_update_yet", "Alias": "Middle East Bahrain" },
+            "us-gov-east-1":  { "Name": "ami-AWS_has_NOT_update_yet", "Alias": "AWS Gov East 1" },
             "us-gov-west-1":  { "Name": "ami-a9afe8c8",          "Alias": "AWS Gov West 1" }
         }
     },
@@ -186,7 +188,9 @@
                                         "Fn::Join": [
                                             "",
                                             [
-                                                "arn:aws:iam::",
+                                                "arn:",
+                                                { "Ref" : "AWS::Partition" },
+                                                ":iam::",
                                                 {
                                                     "Ref": "AWS::AccountId"
                                                 },
@@ -222,7 +226,16 @@
                             "Action": [
                                 "sts:AssumeRole"
                             ],
-                            "Resource": "arn:aws:iam::*:role/aviatrix-*"
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "arn:",
+                                        { "Ref" : "AWS::Partition" },
+                                        ":iam::*:role/aviatrix-*"
+                                    ]
+                                ]
+                            }
                         },
                         {
                             "Effect": "Allow",

--- a/cloudformation-templates/aws-cloudformation-aviatrix-metering-controller.json
+++ b/cloudformation-templates/aws-cloudformation-aviatrix-metering-controller.json
@@ -130,15 +130,18 @@
             "eu-west-3":      { "Name": "ami-0a11977b030622939", "Alias": "Paris" },
             "eu-north-1":     { "Name": "ami-be961dc0",          "Alias": "Stockholm" },
 
+            "ap-east-1":      { "Name": "ami-05b4cf74",          "Alias": "Hong Kong" },
             "ap-southeast-1": { "Name": "ami-02ae4a694e26953b2", "Alias": "Singapore" },
             "ap-southeast-2": { "Name": "ami-06773bff73422d61d", "Alias": "Sydney" },
-            "ap-northeast-1": { "Name": "ami-048dff200571b34fd", "Alias": "Tokyo" },
             "ap-northeast-2": { "Name": "ami-0cb08d1ebcce1495f", "Alias": "Seoul" },
-            "ap-east-1":      { "Name": "ami-05b4cf74",          "Alias": "Hong Kong" },
+            "ap-northeast-1": { "Name": "ami-048dff200571b34fd", "Alias": "Tokyo" },
+            
             "ap-south-1":     { "Name": "ami-09b9ca158a576fa9f", "Alias": "Mumbai" },
 
             "sa-east-1":      { "Name": "ami-0f23734bcd9d53cd8", "Alias": "South America-Sao Paulo" },
-            "us-gov-west-1":  { "Name": "ami-xxxxxxxx",          "Alias": "AWS Gov West 1" }
+            "me-south-1":     { "Name": "ami-AWS_has_NOT_update_yet", "Alias": "Middle East Bahrain" },
+            "us-gov-east-1":  { "Name": "ami-AWS_has_NOT_update_yet", "Alias": "AWS Gov East 1" },
+            "us-gov-west-1":  { "Name": "ami-AWS_has_NOT_update_yet", "Alias": "AWS Gov West 1" }
         }
     },
 
@@ -186,7 +189,9 @@
                                         "Fn::Join": [
                                             "",
                                             [
-                                                "arn:aws:iam::",
+                                                "arn:",
+                                                { "Ref" : "AWS::Partition" },
+                                                ":iam::",
                                                 {
                                                     "Ref": "AWS::AccountId"
                                                 },
@@ -222,7 +227,16 @@
                             "Action": [
                                 "sts:AssumeRole"
                             ],
-                            "Resource": "arn:aws:iam::*:role/aviatrix-*"
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "arn:",
+                                        { "Ref" : "AWS::Partition" },
+                                        ":iam::*:role/aviatrix-*"
+                                    ]
+                                ]
+                            }
                         },
                         {
                             "Effect": "Allow",

--- a/cloudformation-templates/aws-cloudformation-aviatrix-user-vpn-metered.template
+++ b/cloudformation-templates/aws-cloudformation-aviatrix-user-vpn-metered.template
@@ -138,6 +138,7 @@
             "ap-south-1":     { "Name": "ami-0282c5fba757db1a9", "Alias": "Mumbai" },
 
             "sa-east-1":      { "Name": "ami-028d1f3f661679687", "Alias": "South America-Sao Paulo" },
+            "us-gov-east-1":  { "Name": "ami-826382f3",          "Alias": "AWS Gov East 1" },
             "us-gov-west-1":  { "Name": "ami-45226424",          "Alias": "AWS Gov West 1" }
         }
     },

--- a/cloudformation-templates/aws-cloudformation-aviatrix-user-vpn-metered.template
+++ b/cloudformation-templates/aws-cloudformation-aviatrix-user-vpn-metered.template
@@ -124,20 +124,21 @@
 
             "ca-central-1":   { "Name": "ami-023ebbb416d884192", "Alias": "Canada-Central" },
 
-            "eu-central-1":   { "Name": "ami-023ebbb416d884192", "Alias": "Frankfurt" },
+            "eu-central-1":   { "Name": "ami-095e72639fb95cc04", "Alias": "Frankfurt" },
             "eu-west-1":      { "Name": "ami-0d36ea83c80d84db3", "Alias": "Ireland" },
             "eu-west-2":      { "Name": "ami-05c77ad4e031848e1", "Alias": "London" },
             "eu-west-3":      { "Name": "ami-0fbeedf430ffc62a1", "Alias": "Paris" },
             "eu-north-1":     { "Name": "ami-408f043e",          "Alias": "Stockholm" },
 
+            "ap-east-1":      { "Name": "ami-d8413aa9",          "Alias": "Hong Kong" },
             "ap-southeast-1": { "Name": "ami-03504c5cfb9481c48", "Alias": "Singapore" },
             "ap-southeast-2": { "Name": "ami-0bdc267f362ab8d97", "Alias": "Sydney" },
             "ap-northeast-1": { "Name": "ami-0753309521b3cf93c", "Alias": "Tokyo" },
             "ap-northeast-2": { "Name": "ami-03b5e6486f693fe4f", "Alias": "Seoul" },
-            "ap-east-1":      { "Name": "ami-xxxxxxxx",          "Alias": "Hong Kong" },
             "ap-south-1":     { "Name": "ami-0282c5fba757db1a9", "Alias": "Mumbai" },
 
             "sa-east-1":      { "Name": "ami-028d1f3f661679687", "Alias": "South America-Sao Paulo" },
+            "me-south-1":     { "Name": "ami-057dfb7f999f7689c", "Alias": "Middle East Bahrain" },
             "us-gov-east-1":  { "Name": "ami-826382f3",          "Alias": "AWS Gov East 1" },
             "us-gov-west-1":  { "Name": "ami-45226424",          "Alias": "AWS Gov West 1" }
         }
@@ -187,7 +188,9 @@
                                         "Fn::Join": [
                                             "",
                                             [
-                                                "arn:aws:iam::",
+                                                "arn:",
+                                                { "Ref" : "AWS::Partition" },
+                                                ":iam::",
                                                 {
                                                     "Ref": "AWS::AccountId"
                                                 },
@@ -223,7 +226,16 @@
                             "Action": [
                                 "sts:AssumeRole"
                             ],
-                            "Resource": "arn:aws:iam::*:role/aviatrix-*"
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "arn:",
+                                        { "Ref" : "AWS::Partition" },
+                                        ":iam::*:role/aviatrix-*"
+                                    ]
+                                ]
+                            }
                         },
                         {
                             "Effect": "Allow",

--- a/cloudformation-templates/aws-cloudformation-community-byol.template
+++ b/cloudformation-templates/aws-cloudformation-community-byol.template
@@ -117,26 +117,29 @@
 
     "Mappings": {
         "RegionMap": {
-            "us-east-1":      { "Name": "ami-0e507d7959e6369dd" },
-            "us-east-2":      { "Name": "ami-xxxxx" },
-            "us-west-1":      { "Name": "ami-xxxxx" },
-            "us-west-2":      { "Name": "ami-05becf1daa94d501f" },
+            "us-east-1":      { "Name": "ami-0e507d7959e6369dd", "Alias": "Virginia" },
+            "us-east-2":      { "Name": "ami-xxx", "Alias": "Ohio" },
+            "us-west-1":      { "Name": "ami-xxx", "Alias": "California" },
+            "us-west-2":      { "Name": "ami-05becf1daa94d501f", "Alias": "Oregon" },
 
-            "ca-central-1":   { "Name": "ami-xxxxx" },
+            "ca-central-1":   { "Name": "ami-xxx", "Alias": "Canada-Central" },
 
-            "eu-central-1":   { "Name": "ami-xxxxx" },
-            "eu-west-1":      { "Name": "ami-xxxxx" },
-            "eu-west-2":      { "Name": "ami-xxxxx" },
-            "eu-west-3":      { "Name": "ami-xxxxx" },
+            "eu-central-1":   { "Name": "ami-xxx", "Alias": "Frankfurt" },
+            "eu-west-1":      { "Name": "ami-xxx", "Alias": "Ireland" },
+            "eu-west-2":      { "Name": "ami-xxx", "Alias": "London" },
+            "eu-west-3":      { "Name": "ami-xxx", "Alias": "Paris" },
+            "eu-north-1":     { "Name": "ami-xxx",          "Alias": "Stockholm" },
 
-            "ap-southeast-1": { "Name": "ami-xxxxx" },
-            "ap-southeast-2": { "Name": "ami-xxxxx" },
-            "ap-northeast-1": { "Name": "ami-xxxxx" },
-            "ap-northeast-2": { "Name": "ami-xxxxx" },
-            "ap-south-1":     { "Name": "ami-xxxxx" },
+            "ap-southeast-1": { "Name": "ami-xxx", "Alias": "Singapore" },
+            "ap-southeast-2": { "Name": "ami-xxx", "Alias": "Sydney" },
+            "ap-northeast-1": { "Name": "ami-xxx", "Alias": "Tokyo" },
+            "ap-northeast-2": { "Name": "ami-xxx", "Alias": "Seoul" },
+            "ap-east-1":      { "Name": "ami-xxx",          "Alias": "Hong Kong" },
+            "ap-south-1":     { "Name": "ami-xxx", "Alias": "Mumbai" },
 
-            "sa-east-1":      { "Name": "ami-xxxxx" },
-            "us-gov-west-1":  { "Name": "ami-xxxxx" }
+            "sa-east-1":      { "Name": "ami-xxx", "Alias": "South America-Sao Paulo" },
+            "us-gov-east-1":  { "Name": "ami-xxx",          "Alias": "AWS Gov East 1" },
+            "us-gov-west-1":  { "Name": "ami-xxx",          "Alias": "AWS Gov West 1" }
         }
     },
 
@@ -184,7 +187,9 @@
                                         "Fn::Join": [
                                             "",
                                             [
-                                                "arn:aws:iam::",
+                                                "arn:",
+                                                { "Ref" : "AWS::Partition" },
+                                                ":iam::",
                                                 {
                                                     "Ref": "AWS::AccountId"
                                                 },
@@ -220,7 +225,16 @@
                             "Action": [
                                 "sts:AssumeRole"
                             ],
-                            "Resource": "arn:aws:iam::*:role/aviatrix-*"
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "arn:",
+                                        { "Ref" : "AWS::Partition" },
+                                        ":iam::*:role/aviatrix-*"
+                                    ]
+                                ]
+                            }
                         },
                         {
                             "Effect": "Allow",

--- a/cloudformation-templates/aws-cloudformation-community-byol.template
+++ b/cloudformation-templates/aws-cloudformation-community-byol.template
@@ -128,18 +128,19 @@
             "eu-west-1":      { "Name": "ami-xxx", "Alias": "Ireland" },
             "eu-west-2":      { "Name": "ami-xxx", "Alias": "London" },
             "eu-west-3":      { "Name": "ami-xxx", "Alias": "Paris" },
-            "eu-north-1":     { "Name": "ami-xxx",          "Alias": "Stockholm" },
+            "eu-north-1":     { "Name": "ami-xxx", "Alias": "Stockholm" },
 
+            "ap-east-1":      { "Name": "ami-xxx", "Alias": "Hong Kong" },
             "ap-southeast-1": { "Name": "ami-xxx", "Alias": "Singapore" },
             "ap-southeast-2": { "Name": "ami-xxx", "Alias": "Sydney" },
-            "ap-northeast-1": { "Name": "ami-xxx", "Alias": "Tokyo" },
             "ap-northeast-2": { "Name": "ami-xxx", "Alias": "Seoul" },
-            "ap-east-1":      { "Name": "ami-xxx",          "Alias": "Hong Kong" },
+            "ap-northeast-1": { "Name": "ami-xxx", "Alias": "Tokyo" },
             "ap-south-1":     { "Name": "ami-xxx", "Alias": "Mumbai" },
 
             "sa-east-1":      { "Name": "ami-xxx", "Alias": "South America-Sao Paulo" },
-            "us-gov-east-1":  { "Name": "ami-xxx",          "Alias": "AWS Gov East 1" },
-            "us-gov-west-1":  { "Name": "ami-xxx",          "Alias": "AWS Gov West 1" }
+            "me-south-1":     { "Name": "ami-xxx", "Alias": "Middle East Bahrain" },
+            "us-gov-east-1":  { "Name": "ami-xxx", "Alias": "AWS Gov East 1" },
+            "us-gov-west-1":  { "Name": "ami-xxx", "Alias": "AWS Gov West 1" }
         }
     },
 


### PR DESCRIPTION
This commit is to update all CFTs. However, the AWS still hasn't update all AMIs which causing the following AMIs are missing some items:

BYOL: 
    + Missing GovEast1
    + Missing Bahrain

Custom/Utility:
    + Missing GovEast1
    + Missing Bahrain

Meter Controller:
    + Missing GovEast1
    + Missing GovWest1
    + Missing Bahrain