### PR TITLE
Update AMI IDs for AWS Products BYOL and Metering for Version 2020 Ja…

### DIFF
--- a/cloudformation-templates/avx-awsmp-BYOL.template
+++ b/cloudformation-templates/avx-awsmp-BYOL.template
@@ -75,7 +75,7 @@
         },
         "InstanceTypeParam": {
             "Type": "String",
-            "Default": "t2.large",
+            "Default": "t3.large",
             "AllowedValues": [
                 "t2.large",
                 "t2.xlarge",
@@ -93,7 +93,7 @@
                 "c5.xlarge",
                 "c5.2xlarge"
             ],
-            "Description": "Select an instance size for the controller. Default is t2.large"
+            "Description": "Select an instance size for the controller. Default is t3.large"
         }
     },
 
@@ -117,30 +117,30 @@
 
     "Mappings": {
         "RegionMap": {
-            "us-east-1":      { "Name": "ami-02465f499ff5092e1", "Alias": "Virginia" },
-            "us-east-2":      { "Name": "ami-0861f8a0e35a19b0b", "Alias": "Ohio" },
-            "us-west-1":      { "Name": "ami-0cf70ae96639f0057", "Alias": "California" },
-            "us-west-2":      { "Name": "ami-0d1499f297ecddea6", "Alias": "Oregon" },
+            "us-east-1":      { "Name": "ami-0d7263d5d4871e9e7", "Alias": "Virginia" },
+            "us-east-2":      { "Name": "ami-04f98decb12358a88", "Alias": "Ohio" },
+            "us-west-1":      { "Name": "ami-0156478ef6fdd19f0", "Alias": "California" },
+            "us-west-2":      { "Name": "ami-09f328d130f23ad6b", "Alias": "Oregon" },
 
-            "ca-central-1":   { "Name": "ami-08ca66ca024bbce49", "Alias": "Canada-Central" },
+            "ca-central-1":   { "Name": "ami-08f457f76c68c6c87", "Alias": "Canada-Central" },
 
-            "eu-central-1":   { "Name": "ami-0f27d29114cb3e116", "Alias": "Frankfurt" },
-            "eu-west-1":      { "Name": "ami-08d86496a8dcb9d33", "Alias": "Ireland" },
-            "eu-west-2":      { "Name": "ami-001bdb44b4e47313a", "Alias": "London" },
-            "eu-west-3":      { "Name": "ami-01838788ed74ad98d", "Alias": "Paris" },
-            "eu-north-1":     { "Name": "ami-b2f378cc",          "Alias": "Stockholm" },
+            "eu-central-1":   { "Name": "ami-00629d1810b54c3e4", "Alias": "Frankfurt" },
+            "eu-west-1":      { "Name": "ami-0fe8515a699fdf040", "Alias": "Ireland" },
+            "eu-west-2":      { "Name": "ami-0e727ff47bacc8203", "Alias": "London" },
+            "eu-west-3":      { "Name": "ami-09d513d249417723e", "Alias": "Paris" },
+            "eu-north-1":     { "Name": "ami-086f3708cda52713c", "Alias": "Stockholm" },
 
-            "ap-east-1":      { "Name": "ami-9a552eeb",          "Alias": "Hong Kong" },
-            "ap-southeast-1": { "Name": "ami-0a9c6a012c943b907", "Alias": "Singapore" },
-            "ap-southeast-2": { "Name": "ami-0e4d20f09c0318644", "Alias": "Sydney" },
-            "ap-northeast-2": { "Name": "ami-0971c3882816c1bc4", "Alias": "Seoul" },
-            "ap-northeast-1": { "Name": "ami-0d5e9b905bf30d2d3", "Alias": "Tokyo" },
-            "ap-south-1":     { "Name": "ami-00c1c3e9df7b9ddd4", "Alias": "Mumbai" },
+            "ap-east-1":      { "Name": "ami-07986a03c811ce483", "Alias": "Hong Kong" },
+            "ap-southeast-1": { "Name": "ami-0c75640cc661277ba", "Alias": "Singapore" },
+            "ap-southeast-2": { "Name": "ami-0b790836acd673520", "Alias": "Sydney" },
+            "ap-northeast-2": { "Name": "ami-0fb33e49410f1d7fc", "Alias": "Seoul" },
+            "ap-northeast-1": { "Name": "ami-00d0f2f15c0868668", "Alias": "Tokyo" },
+            "ap-south-1":     { "Name": "ami-024d28b578b36467a", "Alias": "Mumbai" },
 
-            "sa-east-1":      { "Name": "ami-0696240d0fc2ecc53", "Alias": "South America-Sao Paulo" },
+            "sa-east-1":      { "Name": "ami-0cf2883cc2a6ff514", "Alias": "South America-Sao Paulo" },
             "me-south-1":     { "Name": "ami-NOT_available_yet", "Alias": "Middle East Bahrain" },
-            "us-gov-east-1":  { "Name": "ami-fd98788c",          "Alias": "AWS Gov East 1" },
-            "us-gov-west-1":  { "Name": "ami-a9afe8c8",          "Alias": "AWS Gov West 1" }
+            "us-gov-east-1":  { "Name": "ami-a52dcfd4",          "Alias": "AWS Gov East 1" },
+            "us-gov-west-1":  { "Name": "ami-83cbeae2",          "Alias": "AWS Gov West 1" }
         }
     },
 
@@ -286,7 +286,9 @@
                                 "guardduty:Get*",
                                 "guardduty:List*",
                                 "ram:Get*",
-                                "ram:List*"
+                                "ram:List*",
+                                "networkmanager:Get*",
+                                "networkmanager:List*"
                             ],
                             "Resource": "*"
                         },
@@ -299,6 +301,8 @@
                                 "ec2:CreateNetworkAclEntry",
                                 "ec2:ReplaceNetworkAclEntry",
                                 "ec2:DeleteNetworkAclEntry",
+                                "ec2:AssociateVpcCidrBlock",
+                                "ec2:AssociateSubnetCidrBlock",
                                 "ec2:CreateSubnet",
                                 "ec2:DeleteSubnet",
                                 "ec2:ModifySubnetAttribute",
@@ -437,8 +441,10 @@
                                 "route53:ChangeResourceRecordSets",
                                 "ec2:*Volume*",
                                 "ec2:*Snapshot*",
+                                "ec2:*TransitGatewayPeeringAttachment",
                                 "guardduty:*",
-                                "globalaccelerator:*"
+                                "globalaccelerator:*",
+                                "networkmanager:*"
                             ],
                             "Resource": "*"
                         }

--- a/cloudformation-templates/aws-cloudformation-aviatrix-metering-controller.json
+++ b/cloudformation-templates/aws-cloudformation-aviatrix-metering-controller.json
@@ -75,7 +75,7 @@
         },
         "InstanceTypeParam": {
             "Type": "String",
-            "Default": "t2.large",
+            "Default": "t3.large",
             "AllowedValues": [
                 "t2.large",
                 "t2.xlarge",
@@ -93,7 +93,7 @@
                 "c5.xlarge",
                 "c5.2xlarge"
             ],
-            "Description": "Select an instance size for the controller. Default is t2.large"
+            "Description": "Select an instance size for the controller. Default is t3.large"
         }
     },
 
@@ -117,31 +117,31 @@
 
     "Mappings": {
         "RegionMap": {
-            "us-east-1":      { "Name": "ami-087b5ab4feb053b4b", "Alias": "Virginia" },
-            "us-east-2":      { "Name": "ami-0bc1db3a5b89c6aef", "Alias": "Ohio" },
-            "us-west-1":      { "Name": "ami-0a928ae10544ec78e", "Alias": "California" },
-            "us-west-2":      { "Name": "ami-0f5b26bac60280d69", "Alias": "Oregon" },
+            "us-east-1":      { "Name": "ami-00d38fb17ad96f990", "Alias": "Virginia" },
+            "us-east-2":      { "Name": "ami-0d79c5a2291f2eaf0", "Alias": "Ohio" },
+            "us-west-1":      { "Name": "ami-0ac232afebae6c77b", "Alias": "California" },
+            "us-west-2":      { "Name": "ami-0c9f2675d54b40ba7", "Alias": "Oregon" },
 
-            "ca-central-1":   { "Name": "ami-031442f061af55923", "Alias": "Canada-Central" },
+            "ca-central-1":   { "Name": "ami-0d752b5104cdbd814", "Alias": "Canada-Central" },
 
-            "eu-central-1":   { "Name": "ami-0cf0c16d58a50f19b", "Alias": "Frankfurt" },
-            "eu-west-1":      { "Name": "ami-0301c0164e6deb6df", "Alias": "Ireland" },
-            "eu-west-2":      { "Name": "ami-04b5c38db962b3c13", "Alias": "London" },
-            "eu-west-3":      { "Name": "ami-0a11977b030622939", "Alias": "Paris" },
-            "eu-north-1":     { "Name": "ami-be961dc0",          "Alias": "Stockholm" },
+            "eu-central-1":   { "Name": "ami-00ae1ee1cdcb97bde", "Alias": "Frankfurt" },
+            "eu-west-1":      { "Name": "ami-0b6164a9be512d70b", "Alias": "Ireland" },
+            "eu-west-2":      { "Name": "ami-0bd8f915015fe2350", "Alias": "London" },
+            "eu-west-3":      { "Name": "ami-00ec70327ff48ab79", "Alias": "Paris" },
+            "eu-north-1":     { "Name": "ami-0e9f5f029d14cf107", "Alias": "Stockholm" },
 
-            "ap-east-1":      { "Name": "ami-05b4cf74",          "Alias": "Hong Kong" },
-            "ap-southeast-1": { "Name": "ami-02ae4a694e26953b2", "Alias": "Singapore" },
-            "ap-southeast-2": { "Name": "ami-06773bff73422d61d", "Alias": "Sydney" },
-            "ap-northeast-2": { "Name": "ami-0cb08d1ebcce1495f", "Alias": "Seoul" },
-            "ap-northeast-1": { "Name": "ami-048dff200571b34fd", "Alias": "Tokyo" },
+            "ap-east-1":      { "Name": "ami-011912838bec420cd", "Alias": "Hong Kong" },
+            "ap-southeast-1": { "Name": "ami-06d99c63ae0c318ac", "Alias": "Singapore" },
+            "ap-southeast-2": { "Name": "ami-086d1a70912834b15", "Alias": "Sydney" },
+            "ap-northeast-2": { "Name": "ami-047afa71f0e66fd98", "Alias": "Seoul" },
+            "ap-northeast-1": { "Name": "ami-048dfc6b9a6b78b51", "Alias": "Tokyo" },
             
-            "ap-south-1":     { "Name": "ami-09b9ca158a576fa9f", "Alias": "Mumbai" },
+            "ap-south-1":     { "Name": "ami-00a501492d15efd2a", "Alias": "Mumbai" },
 
-            "sa-east-1":      { "Name": "ami-0f23734bcd9d53cd8", "Alias": "South America-Sao Paulo" },
+            "sa-east-1":      { "Name": "ami-05f858335beb5806d", "Alias": "South America-Sao Paulo" },
             "me-south-1":     { "Name": "ami-NOT_available_yet", "Alias": "Middle East Bahrain" },
-            "us-gov-east-1":  { "Name": "ami-21997950",          "Alias": "AWS Gov East 1" },
-            "us-gov-west-1":  { "Name": "ami-e3377782",          "Alias": "AWS Gov West 1" }
+            "us-gov-east-1":  { "Name": "ami-6f3edc1e",          "Alias": "AWS Gov East 1" },
+            "us-gov-west-1":  { "Name": "ami-e980a188",          "Alias": "AWS Gov West 1" }
         }
     },
 
@@ -287,7 +287,9 @@
                                 "guardduty:Get*",
                                 "guardduty:List*",
                                 "ram:Get*",
-                                "ram:List*"
+                                "ram:List*",
+                                "networkmanager:Get*",
+                                "networkmanager:List*"
                             ],
                             "Resource": "*"
                         },
@@ -300,6 +302,8 @@
                                 "ec2:CreateNetworkAclEntry",
                                 "ec2:ReplaceNetworkAclEntry",
                                 "ec2:DeleteNetworkAclEntry",
+                                "ec2:AssociateVpcCidrBlock",
+                                "ec2:AssociateSubnetCidrBlock",
                                 "ec2:CreateSubnet",
                                 "ec2:DeleteSubnet",
                                 "ec2:ModifySubnetAttribute",
@@ -438,8 +442,10 @@
                                 "route53:ChangeResourceRecordSets",
                                 "ec2:*Volume*",
                                 "ec2:*Snapshot*",
+                                "ec2:*TransitGatewayPeeringAttachment",
                                 "guardduty:*",
-                                "globalaccelerator:*"
+                                "globalaccelerator:*",
+                                "networkmanager:*"
                             ],
                             "Resource": "*"
                         }

--- a/cloudformation-templates/aws-cloudformation-community-byol.template
+++ b/cloudformation-templates/aws-cloudformation-community-byol.template
@@ -128,19 +128,18 @@
             "eu-west-1":      { "Name": "ami-xxx", "Alias": "Ireland" },
             "eu-west-2":      { "Name": "ami-xxx", "Alias": "London" },
             "eu-west-3":      { "Name": "ami-xxx", "Alias": "Paris" },
-            "eu-north-1":     { "Name": "ami-xxx", "Alias": "Stockholm" },
+            "eu-north-1":     { "Name": "ami-xxx",          "Alias": "Stockholm" },
 
-            "ap-east-1":      { "Name": "ami-xxx", "Alias": "Hong Kong" },
             "ap-southeast-1": { "Name": "ami-xxx", "Alias": "Singapore" },
             "ap-southeast-2": { "Name": "ami-xxx", "Alias": "Sydney" },
-            "ap-northeast-2": { "Name": "ami-xxx", "Alias": "Seoul" },
             "ap-northeast-1": { "Name": "ami-xxx", "Alias": "Tokyo" },
+            "ap-northeast-2": { "Name": "ami-xxx", "Alias": "Seoul" },
+            "ap-east-1":      { "Name": "ami-xxx",          "Alias": "Hong Kong" },
             "ap-south-1":     { "Name": "ami-xxx", "Alias": "Mumbai" },
 
             "sa-east-1":      { "Name": "ami-xxx", "Alias": "South America-Sao Paulo" },
-            "me-south-1":     { "Name": "ami-xxx", "Alias": "Middle East Bahrain" },
-            "us-gov-east-1":  { "Name": "ami-xxx", "Alias": "AWS Gov East 1" },
-            "us-gov-west-1":  { "Name": "ami-xxx", "Alias": "AWS Gov West 1" }
+            "us-gov-east-1":  { "Name": "ami-xxx",          "Alias": "AWS Gov East 1" },
+            "us-gov-west-1":  { "Name": "ami-xxx",          "Alias": "AWS Gov West 1" }
         }
     },
 


### PR DESCRIPTION
+ Update AMI IDs for AWS Products BYOL and Metering for Version 2020 Jan 19th
+ Change default EC2 instance type from "t2.large" to "t3.large"

