### PR TITLE
Update Meter CFT with AmiDate20200310, but missing AWS-Gov regions

### DIFF
--- a/cloudformation-templates/aws-cloudformation-aviatrix-metering-controller.json
+++ b/cloudformation-templates/aws-cloudformation-aviatrix-metering-controller.json
@@ -117,29 +117,29 @@
 
     "Mappings": {
         "RegionMap": {
-            "us-east-1":      { "Name": "ami-00d38fb17ad96f990", "Alias": "Virginia" },
-            "us-east-2":      { "Name": "ami-0d79c5a2291f2eaf0", "Alias": "Ohio" },
-            "us-west-1":      { "Name": "ami-0ac232afebae6c77b", "Alias": "California" },
-            "us-west-2":      { "Name": "ami-0c9f2675d54b40ba7", "Alias": "Oregon" },
+            "us-east-1":      { "Name": "ami-0858e90edb88d9de0", "Alias": "Virginia" },
+            "us-east-2":      { "Name": "ami-0c99b9f0c65623ad2", "Alias": "Ohio" },
+            "us-west-1":      { "Name": "ami-0d911542125beb411", "Alias": "California" },
+            "us-west-2":      { "Name": "ami-0bcc520c761a209d9", "Alias": "Oregon" },
 
-            "ca-central-1":   { "Name": "ami-0d752b5104cdbd814", "Alias": "Canada-Central" },
+            "ca-central-1":   { "Name": "ami-060fdad9585f00295", "Alias": "Canada-Central" },
 
-            "eu-central-1":   { "Name": "ami-00ae1ee1cdcb97bde", "Alias": "Frankfurt" },
-            "eu-west-1":      { "Name": "ami-0b6164a9be512d70b", "Alias": "Ireland" },
-            "eu-west-2":      { "Name": "ami-0bd8f915015fe2350", "Alias": "London" },
-            "eu-west-3":      { "Name": "ami-00ec70327ff48ab79", "Alias": "Paris" },
-            "eu-north-1":     { "Name": "ami-0e9f5f029d14cf107", "Alias": "Stockholm" },
+            "eu-central-1":   { "Name": "ami-0fc80ef6e32247baa", "Alias": "Frankfurt" },
+            "eu-west-1":      { "Name": "ami-0b61fa1e620089e80", "Alias": "Ireland" },
+            "eu-west-2":      { "Name": "ami-001ef594221572b0d", "Alias": "London" },
+            "eu-west-3":      { "Name": "ami-017ef356604f5b4f9", "Alias": "Paris" },
+            "eu-north-1":     { "Name": "ami-0e34fab551dfb327a", "Alias": "Stockholm" },
 
-            "ap-east-1":      { "Name": "ami-011912838bec420cd", "Alias": "Hong Kong" },
-            "ap-southeast-1": { "Name": "ami-06d99c63ae0c318ac", "Alias": "Singapore" },
-            "ap-southeast-2": { "Name": "ami-086d1a70912834b15", "Alias": "Sydney" },
-            "ap-northeast-2": { "Name": "ami-047afa71f0e66fd98", "Alias": "Seoul" },
-            "ap-northeast-1": { "Name": "ami-048dfc6b9a6b78b51", "Alias": "Tokyo" },
+            "ap-east-1":      { "Name": "ami-0ff545e8d0ea44e81", "Alias": "Hong Kong" },
+            "ap-southeast-1": { "Name": "ami-08022902184c1dba9", "Alias": "Singapore" },
+            "ap-southeast-2": { "Name": "ami-093acc21a521ba0e5", "Alias": "Sydney" },
+            "ap-northeast-2": { "Name": "ami-0ade8b69f4b76ee48", "Alias": "Seoul" },
+            "ap-northeast-1": { "Name": "ami-011faa0cf53000ace", "Alias": "Tokyo" },
             
-            "ap-south-1":     { "Name": "ami-00a501492d15efd2a", "Alias": "Mumbai" },
+            "ap-south-1":     { "Name": "ami-00c57ee0b7fd172ad", "Alias": "Mumbai" },
 
-            "sa-east-1":      { "Name": "ami-05f858335beb5806d", "Alias": "South America-Sao Paulo" },
-            "me-south-1":     { "Name": "ami-NOT_available_yet", "Alias": "Middle East Bahrain" },
+            "sa-east-1":      { "Name": "ami-074d9a5be52f71510", "Alias": "South America-Sao Paulo" },
+            "me-south-1":     { "Name": "ami-027e3f09d5ca229e1", "Alias": "Middle East Bahrain" },
             "us-gov-east-1":  { "Name": "ami-6f3edc1e",          "Alias": "AWS Gov East 1" },
             "us-gov-west-1":  { "Name": "ami-e980a188",          "Alias": "AWS Gov West 1" }
         }


### PR DESCRIPTION
* Update controller Metered image with the latest AMI-Date 2020-03-10 for all region. However, AWS seems to forgot supporting this latest version for AWS-Gov regions.

* As mentioned above, in this commit, the 2 AWS-Gov regions will keep using the old AMI until notified.